### PR TITLE
Initialize the default customer, rename certain environment variables

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -26,7 +26,7 @@ export default defineNuxtConfig({
     clientId: process.env.PLANSHIP_API_CLIENT_ID,
     clientSecret: process.env.PLANSHIP_API_CLIENT_SECRET,
     baseUrl: process.env.PLANSHIP_BASE_URL ?? '',
-    webSocketUrl: process.env.PLANSHIP_WEBSOCKET_URL ?? ''
+    webSocketUrl: process.env.PLANSHIP_WEBSOCKET_URL ?? '',
   },
 
   devtools: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -23,8 +23,8 @@ export default defineNuxtConfig({
 
   planship: {
     productSlug: 'clicker-demo',
-    clientId: process.env.PLANSHIP_CLIENT_ID,
-    clientSecret: process.env.PLANSHIP_CLIENT_SECRET,
+    clientId: process.env.PLANSHIP_API_CLIENT_ID,
+    clientSecret: process.env.PLANSHIP_API_CLIENT_SECRET,
     baseUrl: process.env.PLANSHIP_BASE_URL ?? '',
     webSocketUrl: process.env.PLANSHIP_WEBSOCKET_URL ?? ''
   },

--- a/plugins/initPlanshipCustomer.server.ts
+++ b/plugins/initPlanshipCustomer.server.ts
@@ -1,0 +1,44 @@
+import { Planship, CustomerSubscriptionWithPlan } from '@planship/fetch'
+
+// This plugin initializes a Planship customer if one doesn't already exist for the default user.
+// These steps would typically be executed as a part of of customer registration flow, but this example app doesn't
+// implement the sign-up/sign-in flow.
+
+export default defineNuxtPlugin(async () => {
+  const userId = 'vader@empire.gov'
+  const planshipClient = new Planship(
+    'clicker-demo',
+    {
+      clientId: process.env.PLANSHIP_API_CLIENT_ID,
+      clientSecret: process.env.PLANSHIP_API_CLIENT_SECRET,
+    },
+    {
+      baseUrl: process.env.PLANSHIP_BASE_URL ?? '',
+      webSocketUrl: process.env.PLANSHIP_WEBSOCKET_URL ?? ''
+    },
+  )
+  let customer
+  try {
+    customer = await planshipClient.getCustomer(userId)
+  } catch (error) {
+    if (error?.response?.status === 404) {
+      // Create a Planship customer for the default user if one doesn't exist. This would typically be called during
+      // a new customer sign-up, but this example app doesn't implement the sign-up/sign-in flow.
+      customer = await planshipClient.createCustomer({ alternativeId: userId })
+      console.log(`Created Planship customer for user ${userId}:`, customer.id)
+    } else {
+      throw error
+    }
+  }
+  if (customer) {
+    const subscriptions: CustomerSubscriptionWithPlan[] = await planshipClient.listSubscriptions(customer.id)
+    if (subscriptions.length === 0) {
+      // Create an initial Planship subscription to the Personal plan for the default user if one doesn't exist.
+      // This would typically be called when a customer chooses their initial plan upon sign-up, but this example app
+      // doesn't implement the sign-up/sign-in flow.
+      const subscription = await planshipClient.createSubscription(customer.id, 'personal')
+      console.log(`Created initial Planship subscription to plan Personal for user ${userId}:`, subscription.id)
+    }
+  }
+
+})


### PR DESCRIPTION
This PR, when merged, will add a server plugin that creates a Planship customer for `vader@empire.gov` user along with a default subscription if they don't exist.

Other changes include renaming certain environment variables used by the Nuxt config so they are aligned with the README, other example apps (e.g. NextJS one) and libraries. The following changes have been made:
`PLANSHIP_CLIENT_ID` -> `PLANSHIP_API_CLIENT_ID`
`PLANSHIP_CLIENT_SECRET` -> `PLANSHIP_API_CLIENT_SECRET`